### PR TITLE
fix: set leeway value to prevent clock skew

### DIFF
--- a/src/Auth/AccessToken.php
+++ b/src/Auth/AccessToken.php
@@ -197,6 +197,7 @@ class AccessToken
             $key = new Key($this->formatRawKeyToPEM($publicKeyString), $alg);
 
             // Verify the token
+            JWT::$leeway = 30; // Allow 30 seconds clock skew
             JWT::decode($this->getAccessToken(), $key);
 
             return true;


### PR DESCRIPTION
There's a chance what server time and client time doesn't match.